### PR TITLE
Use Source Path instead of Archive Path if Archive Path is "None"

### DIFF
--- a/scripts/post-consumption/content-matching/post-consumption-wrapper.sh
+++ b/scripts/post-consumption/content-matching/post-consumption-wrapper.sh
@@ -12,10 +12,18 @@ SCRIPT_DIR=$(dirname "$SCRIPT_PATH")
 # Make sure organize-tool and poppler-utils has been installed
 # on your system (resp. container, via custom-cont-init.d)
 
+# In certain cases, like encrypted PDFs, no archived version is created by paperless.
+# In this case, the archive path is "None". However, organize can still use the file.
+# Therefore, use the source path instead.
+if [[ "${DOCUMENT_ARCHIVE_PATH}" != "None" ]] ;then
+    DOCUMENT="${DOCUMENT_ARCHIVE_PATH}" 
+else
+    DOCUMENT="${DOCUMENT_SOURCE_PATH}" 
+fi
 # organize-tool doesn't accept full file path as argument
 # but expects directory and filename pattern without extension instead
-export DOCUMENT_ARCHIVE_FILENAME=$(basename "${DOCUMENT_ARCHIVE_PATH}")
-export DOCUMENT_ARCHIVE_DIR=$(dirname "${DOCUMENT_ARCHIVE_PATH}")
+export DOCUMENT_ARCHIVE_FILENAME=$(basename "${DOCUMENT}")
+export DOCUMENT_ARCHIVE_DIR=$(dirname "${DOCUMENT}")
 
 # While organize supports environment variables as placeholders in it's configuration,
 # it's not yet supported everywhere in the configuration (e.g. filters),


### PR DESCRIPTION
If no archived version of a document is created, like for encrypted PDFs, organize-tool tries to use the source path instead of the archive path.